### PR TITLE
Support ADDITIONAL_ODOO_RC env var

### DIFF
--- a/confd/10.0/templates/odoo.cfg.tmpl
+++ b/confd/10.0/templates/odoo.cfg.tmpl
@@ -49,3 +49,4 @@ proxy_mode = True
 ; xmlrpcs_interface =
 ; xmlrpcs_port = 8071
 unaccent = {{ getv "/unaccent" "False" }}
+{{ getv "/additional/odoo/rc" "" }}

--- a/confd/11.0/templates/odoo.cfg.tmpl
+++ b/confd/11.0/templates/odoo.cfg.tmpl
@@ -50,3 +50,4 @@ proxy_mode = True
 ; smtp_ssl = False
 ; smtp_user = False
 unaccent = {{ getv "/unaccent" "False" }}
+{{ getv "/additional/odoo/rc" "" }}

--- a/confd/12.0/templates/odoo.cfg.tmpl
+++ b/confd/12.0/templates/odoo.cfg.tmpl
@@ -50,3 +50,4 @@ proxy_mode = True
 ; smtp_ssl = False
 ; smtp_user = False
 unaccent = {{ getv "/unaccent" "False" }}
+{{ getv "/additional/odoo/rc" "" }}

--- a/confd/8.0/templates/odoo.cfg.tmpl
+++ b/confd/8.0/templates/odoo.cfg.tmpl
@@ -48,3 +48,4 @@ proxy_mode = True
 ; xmlrpcs_interface =
 ; xmlrpcs_port = 8071
 unaccent = {{ getv "/unaccent" "False" }}
+{{ getv "/additional/odoo/rc" "" }}

--- a/confd/9.0/templates/odoo.cfg.tmpl
+++ b/confd/9.0/templates/odoo.cfg.tmpl
@@ -48,3 +48,4 @@ proxy_mode = True
 ; xmlrpcs_interface =
 ; xmlrpcs_port = 8071
 unaccent = {{ getv "/unaccent" "False" }}
+{{ getv "/additional/odoo/rc" "" }}


### PR DESCRIPTION
For situations where /etc/odoo.cfg must be extended.