### PR TITLE
Fix ADDITIONAL_ODOO_RC env var

### DIFF
--- a/confd/10.0/conf.d/odoo.cfg.toml
+++ b/confd/10.0/conf.d/odoo.cfg.toml
@@ -28,4 +28,5 @@ keys = [
   "/without/demo",
   "/server/wide/modules",
   "/unaccent",
+  "/additional/odoo/rc",
 ]

--- a/confd/11.0/conf.d/odoo.cfg.toml
+++ b/confd/11.0/conf.d/odoo.cfg.toml
@@ -29,4 +29,5 @@ keys = [
   "/without/demo",
   "/server/wide/modules",
   "/unaccent",
+  "/additional/odoo/rc",
 ]

--- a/confd/12.0/conf.d/odoo.cfg.toml
+++ b/confd/12.0/conf.d/odoo.cfg.toml
@@ -29,4 +29,5 @@ keys = [
   "/without/demo",
   "/server/wide/modules",
   "/unaccent",
+  "/additional/odoo/rc",
 ]

--- a/confd/8.0/conf.d/odoo.cfg.toml
+++ b/confd/8.0/conf.d/odoo.cfg.toml
@@ -28,4 +28,5 @@ keys = [
   "/without/demo",
   "/server/wide/modules",
   "/unaccent",
+  "/additional/odoo/rc",
 ]

--- a/confd/9.0/conf.d/odoo.cfg.toml
+++ b/confd/9.0/conf.d/odoo.cfg.toml
@@ -28,4 +28,5 @@ keys = [
   "/without/demo",
   "/server/wide/modules",
   "/unaccent",
+  "/additional/odoo/rc",
 ]


### PR DESCRIPTION
Declares the env var key '/additional/odoo/rc' into the template resource config file of confd