### PR TITLE
Add entrypoint parts to set `report.url`, `web.base.url` and `web.base.url.freeze`

### DIFF
--- a/Dockerfile-10.0
+++ b/Dockerfile-10.0
@@ -43,7 +43,7 @@ EXPOSE 8069 8072
 COPY ./root-banner /etc
 RUN echo "cat /etc/root-banner" >> /root/.bashrc
 
-RUN mkdir -p /odoo/start-entrypoint.d
+COPY ./start-entrypoint.d /odoo/start-entrypoint.d
 COPY ./bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["odoo"]

--- a/Dockerfile-11.0
+++ b/Dockerfile-11.0
@@ -46,7 +46,7 @@ EXPOSE 8069 8072
 COPY ./root-banner /etc
 RUN echo "cat /etc/root-banner" >> /root/.bashrc
 
-RUN mkdir -p /odoo/start-entrypoint.d
+COPY ./start-entrypoint.d /odoo/start-entrypoint.d
 COPY ./bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["odoo"]

--- a/Dockerfile-12.0
+++ b/Dockerfile-12.0
@@ -45,7 +45,7 @@ EXPOSE 8069 8072
 COPY ./root-banner /etc
 RUN echo "cat /etc/root-banner" >> /root/.bashrc
 
-RUN mkdir -p /odoo/start-entrypoint.d
+COPY ./start-entrypoint.d /odoo/start-entrypoint.d
 COPY ./bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["odoo"]

--- a/Dockerfile-13.0
+++ b/Dockerfile-13.0
@@ -45,7 +45,7 @@ EXPOSE 8069 8072
 COPY ./root-banner /etc
 RUN echo "cat /etc/root-banner" >> /root/.bashrc
 
-RUN mkdir -p /odoo/start-entrypoint.d
+COPY ./start-entrypoint.d /odoo/start-entrypoint.d
 COPY ./bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["odoo"]

--- a/Dockerfile-14.0
+++ b/Dockerfile-14.0
@@ -45,7 +45,7 @@ EXPOSE 8069 8072
 COPY ./root-banner /etc
 RUN echo "cat /etc/root-banner" >> /root/.bashrc
 
-RUN mkdir -p /odoo/start-entrypoint.d
+COPY ./start-entrypoint.d /odoo/start-entrypoint.d
 COPY ./bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["odoo"]

--- a/Dockerfile-15.0
+++ b/Dockerfile-15.0
@@ -45,7 +45,7 @@ EXPOSE 8069 8072
 COPY ./root-banner /etc
 RUN echo "cat /etc/root-banner" >> /root/.bashrc
 
-RUN mkdir -p /odoo/start-entrypoint.d
+COPY ./start-entrypoint.d /odoo/start-entrypoint.d
 COPY ./bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["odoo"]

--- a/Dockerfile-16.0
+++ b/Dockerfile-16.0
@@ -45,7 +45,7 @@ EXPOSE 8069 8072
 COPY ./root-banner /etc
 RUN echo "cat /etc/root-banner" >> /root/.bashrc
 
-RUN mkdir -p /odoo/start-entrypoint.d
+COPY ./start-entrypoint.d /odoo/start-entrypoint.d
 COPY ./bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["odoo"]

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,6 @@
+* 2023-04-24: add support for ``ODOO_BASE_URL`` to set the ``web.base.url`` and
+  ``web.base.url.freeze`` system parameters, and ``ODOO_REPORT_URL`` environment
+  variables to set the ``report.url`` system parameter
 * 2022-05-13: preliminary Odoo 16 support
 * 2021-08-31: add warning banner when entering root shell
 * 2021-08-31: build with github actions to ghcr.io

--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,13 @@ The following environment variables are used to generate the Odoo configuration 
 * ``WITHOUT_DEMO``
 * ``WORKERS``
 
+The following environment variables are processed by the entrypoint, if the psql client
+is installed (which is not the case by default):
+
+* ``ODOO_BASE_URL`` sets the ``web.base.url`` system parameter, and forces
+  ``web.base.urL.freeze`` to ``True``.
+* ``ODOO_REPORT_URL`` sets the ``report.url`` system parameter.
+
 Examples
 ========
 

--- a/start-entrypoint.d/000_set_base_url
+++ b/start-entrypoint.d/000_set_base_url
@@ -1,0 +1,52 @@
+# Copyright 2016-2022 Camptocamp SA (http://www.camptocamp.com)
+#!/bin/bash
+
+DOMAIN="${ODOO_BASE_URL}"
+
+if [ -n "$DOMAIN" ]; then
+
+  if ! command -v psql &> /dev/null
+  then
+      echo "Command 'psql' could not be found, ignoring script"
+      exit 0
+  fi
+
+  if [ "$( psql -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" )" != '1' ]
+  then
+      echo "Database does not exist, ignoring script"
+      exit 0
+  fi
+
+  if [ "$( psql $DB_NAME -tAc "SELECT 1 FROM pg_tables WHERE tablename='ir_config_parameter'" )" != '1' ]
+  then
+      echo "Database $DB_NAME not initialized, ignoring script"
+      exit 0
+  fi
+
+  echo "Setting Base URL to domain ${DOMAIN}"
+  psql --quiet << EOF
+
+  WITH update_param AS (
+    UPDATE ir_config_parameter
+    SET value = '${DOMAIN}'
+    WHERE key = 'web.base.url'
+    RETURNING *
+  )
+  INSERT INTO ir_config_parameter
+  (value, key, create_uid, write_uid, create_date, write_date)
+  SELECT '${DOMAIN}', 'web.base.url', 1, 1, now(), now()
+  WHERE NOT EXISTS (SELECT * FROM update_param);
+
+  WITH update_param AS (
+    UPDATE ir_config_parameter
+    SET value = 'True'
+    WHERE key = 'web.base.url.freeze'
+    RETURNING *
+  )
+  INSERT INTO ir_config_parameter
+  (value, key, create_uid, write_uid, create_date, write_date)
+  SELECT 'True', 'web.base.url.freeze', 1, 1, now(), now()
+  WHERE NOT EXISTS (SELECT * FROM update_param);
+
+EOF
+fi

--- a/start-entrypoint.d/000_set_base_url
+++ b/start-entrypoint.d/000_set_base_url
@@ -1,5 +1,7 @@
-# Copyright 2016-2022 Camptocamp SA (http://www.camptocamp.com)
 #!/bin/bash
+
+# Copyright 2016-2022 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2023 ACSONE SA (http://acsone.eu)
 
 DOMAIN="${ODOO_BASE_URL}"
 
@@ -7,23 +9,23 @@ if [ -n "$DOMAIN" ]; then
 
   if ! command -v psql &> /dev/null
   then
-      echo "Command 'psql' could not be found, ignoring script"
+      echo "Command 'psql' could not be found, skipping $0"
       exit 0
   fi
 
   if [ "$( psql -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" )" != '1' ]
   then
-      echo "Database does not exist, ignoring script"
+      echo "Database $DB_NAME does not exist, skipping $0"
       exit 0
   fi
 
   if [ "$( psql $DB_NAME -tAc "SELECT 1 FROM pg_tables WHERE tablename='ir_config_parameter'" )" != '1' ]
   then
-      echo "Database $DB_NAME not initialized, ignoring script"
+      echo "Database $DB_NAME not initialized, skipping $0"
       exit 0
   fi
 
-  echo "Setting Base URL to domain ${DOMAIN}"
+  echo "Setting Base URL to ${DOMAIN}"
   psql --quiet << EOF
 
   WITH update_param AS (

--- a/start-entrypoint.d/001_set_report_url
+++ b/start-entrypoint.d/001_set_report_url
@@ -1,0 +1,41 @@
+# Copyright 2016-2022 Camptocamp SA (http://www.camptocamp.com)
+#!/bin/bash
+
+DOMAIN="${ODOO_REPORT_URL}"
+
+if [ -n "$DOMAIN" ]; then
+
+  if ! command -v psql &> /dev/null
+  then
+      echo "Command 'psql' could not be found, ignoring script"
+      exit
+  fi
+
+  if [ "$( psql -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" )" != '1' ]
+  then
+      echo "Database does not exist, ignoring script"
+      exit 0
+  fi
+
+  if [ "$( psql $DB_NAME -tAc "SELECT 1 FROM pg_tables WHERE tablename='ir_config_parameter'" )" != '1' ]
+  then
+      echo "Database $DB_NAME not initialized, ignoring script"
+      exit 0
+  fi
+
+  echo "Setting Report URL to domain ${DOMAIN}"
+  psql --quiet << EOF
+
+  WITH update_param AS (
+    UPDATE ir_config_parameter
+    SET value = '${DOMAIN}'
+    WHERE key = 'report.url'
+    RETURNING *
+  )
+  INSERT INTO ir_config_parameter
+  (value, key, create_uid, write_uid, create_date, write_date)
+  SELECT '${DOMAIN}', 'report.url', 1, 1, now(), now()
+  WHERE NOT EXISTS (SELECT * FROM update_param);
+
+EOF
+fi

--- a/start-entrypoint.d/001_set_report_url
+++ b/start-entrypoint.d/001_set_report_url
@@ -1,5 +1,7 @@
-# Copyright 2016-2022 Camptocamp SA (http://www.camptocamp.com)
 #!/bin/bash
+
+# Copyright 2016-2022 Camptocamp SA (http://www.camptocamp.com)
+# Copyright 2023 ACSONE SA (http://acsone.eu)
 
 DOMAIN="${ODOO_REPORT_URL}"
 
@@ -7,23 +9,23 @@ if [ -n "$DOMAIN" ]; then
 
   if ! command -v psql &> /dev/null
   then
-      echo "Command 'psql' could not be found, ignoring script"
+      echo "Command 'psql' could not be found, skipping $0"
       exit
   fi
 
   if [ "$( psql -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" )" != '1' ]
   then
-      echo "Database does not exist, ignoring script"
+      echo "Database $DB_NAME does not exist, skipping $0"
       exit 0
   fi
 
   if [ "$( psql $DB_NAME -tAc "SELECT 1 FROM pg_tables WHERE tablename='ir_config_parameter'" )" != '1' ]
   then
-      echo "Database $DB_NAME not initialized, ignoring script"
+      echo "Database $DB_NAME not initialized, skipping $0"
       exit 0
   fi
 
-  echo "Setting Report URL to domain ${DOMAIN}"
+  echo "Setting Report URL to ${DOMAIN}"
   psql --quiet << EOF
 
   WITH update_param AS (

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -5,6 +5,8 @@ ARG PYTHONTAG=py310
 
 FROM $IMAGE:$ODOOVERSION-$PYTHONTAG-latest
 
+RUN apt-get update && apt-get install -y postgresql-client --no-install-recommends
+
 # Fake odoo command in PATH
 RUN echo "#!/bin/bash\necho running odoo UID=\$(id -u)\n" > /odoo/bin/odoo \
  && chmod +x /odoo/bin/odoo \

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -1,7 +1,17 @@
 from pathlib import Path
+import os
 import subprocess
 
 HERE = Path(__file__).parent
+
+
+def odoo_version():
+    # /!\ Default must be the same as the ODOOVERSION build arg in test Dockerfile
+    return os.environ.get("ODOOVERSION", "16.0")
+
+
+def parsed_odoo_version():
+    return tuple(int(x) for x in odoo_version().split("."))
 
 
 def compose_run(command, env=None, check=True, volumes=None):


### PR DESCRIPTION
Any script placed in '/odoo/start-entrypoint.d' will be execyted add start of the container before the start of Odoo. Files are run in the lexical sort order of their names (according to the C/POSIX locale character collation rules) as explained into the  command documentation.

TO BE TESTED