### PR TITLE
Add 16.0-py311

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
           - ODOOVERSION: "16.0"
             PYTHONTAG: py310
             PYTHONBIN: python3.10
+          - ODOOVERSION: "16.0"
+            PYTHONTAG: py311
+            PYTHONBIN: python3.11
     steps:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
From https://github.com/odoo/odoo/commit/fbe4932cd583a2cc019644807a7ea248d34eec80 python-3.11 is officialy supported by Odoo 16.0