### PR TITLE
Abandon old builds, tag images per distro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,15 +80,15 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to ghcr.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile-${{ matrix.ODOOVERSION }}
@@ -107,7 +107,7 @@ jobs:
           PYTHONTAG: "${{ matrix.PYTHONTAG }}"
         run: pytest -v tests
       - name: Push image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: Dockerfile-${{ matrix.ODOOVERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,24 +14,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - ODOOVERSION: "8.0"
-            PYTHONTAG: py27
-            PYTHONBIN: python2.7
-          - ODOOVERSION: "9.0"
-            PYTHONTAG: py27
-            PYTHONBIN: python2.7
-          - ODOOVERSION: "10.0"
-            PYTHONTAG: py27
-            PYTHONBIN: python2.7
-          - ODOOVERSION: "11.0"
-            PYTHONTAG: py35
-            PYTHONBIN: python3.5
           - ODOOVERSION: "11.0"
             PYTHONTAG: py36
             PYTHONBIN: python3.6
-          - ODOOVERSION: "12.0"
-            PYTHONTAG: py35
-            PYTHONBIN: python3.5
           - ODOOVERSION: "12.0"
             PYTHONTAG: py36
             PYTHONBIN: python3.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,54 +14,71 @@ jobs:
     strategy:
       matrix:
         include:
+          # /!\ python 3.6 and 3.7 are not supported anymore
           - ODOOVERSION: "11.0"
             PYTHONTAG: py36
             PYTHONBIN: python3.6
+            DISTRO: focal
           - ODOOVERSION: "12.0"
             PYTHONTAG: py36
             PYTHONBIN: python3.6
+            DISTRO: focal
           - ODOOVERSION: "12.0"
             PYTHONTAG: py37
             PYTHONBIN: python3.7
+            DISTRO: focal
           - ODOOVERSION: "13.0"
             PYTHONTAG: py36
             PYTHONBIN: python3.6
+            DISTRO: focal
           - ODOOVERSION: "13.0"
             PYTHONTAG: py37
             PYTHONBIN: python3.7
+            DISTRO: focal
           - ODOOVERSION: "13.0"
             PYTHONTAG: py310
             PYTHONBIN: python3.10
+            DISTRO: focal
           - ODOOVERSION: "14.0"
             PYTHONTAG: py36
             PYTHONBIN: python3.6
+            DISTRO: focal
           - ODOOVERSION: "14.0"
             PYTHONTAG: py37
             PYTHONBIN: python3.7
+            DISTRO: focal
           - ODOOVERSION: "14.0"
             PYTHONTAG: py38
             PYTHONBIN: python3.8
+            DISTRO: focal
           - ODOOVERSION: "14.0"
             PYTHONTAG: py39
             PYTHONBIN: python3.9
+            DISTRO: focal
           - ODOOVERSION: "15.0"
             PYTHONTAG: py38
             PYTHONBIN: python3.8
+            DISTRO: focal
           - ODOOVERSION: "15.0"
             PYTHONTAG: py39
             PYTHONBIN: python3.9
+            DISTRO: focal
           - ODOOVERSION: "16.0"
             PYTHONTAG: py39
             PYTHONBIN: python3.9
+            DISTRO: jammy
           - ODOOVERSION: "16.0"
             PYTHONTAG: py310
             PYTHONBIN: python3.10
+            DISTRO: jammy
           - ODOOVERSION: "16.0"
             PYTHONTAG: py311
             PYTHONBIN: python3.11
+            DISTRO: jammy
           - ODOOVERSION: "17.0"
             PYTHONTAG: py311
             PYTHONBIN: python3.11
+            DISTRO: jammy
     steps:
       - uses: actions/checkout@v3
       - name: Set up Docker Buildx
@@ -79,9 +96,10 @@ jobs:
           file: Dockerfile-${{ matrix.ODOOVERSION }}
           build-args: |
             PYTHONBIN=${{ matrix.PYTHONBIN }}
+            DISTRO=${{ matrix.DISTRO }}
           tags: |
-            ghcr.io/${{ github.repository }}:${{ matrix.ODOOVERSION }}-${{ matrix.PYTHONTAG }}-latest
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:${{ matrix.ODOOVERSION }}-${{ matrix.PYTHONTAG }}-latest
+            ghcr.io/${{ github.repository }}:${{ matrix.ODOOVERSION }}-${{ matrix.PYTHONTAG }}-${{ matrix.DISTRO }}-latest
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:${{ matrix.ODOOVERSION }}-${{ matrix.PYTHONTAG }}-${{ matrix.DISTRO }}-latest
           cache-to: type=local,dest=/tmp/.buildx-cache
           load: true
       - name: Install test pre-requisites
@@ -90,6 +108,7 @@ jobs:
         env:
           ODOOVERSION: "${{ matrix.ODOOVERSION }}"
           PYTHONTAG: "${{ matrix.PYTHONTAG }}"
+          DISTRO: "${{ matrix.DISTRO }}"
         run: pytest -v tests
       - name: Push image
         uses: docker/build-push-action@v5
@@ -98,8 +117,9 @@ jobs:
           file: Dockerfile-${{ matrix.ODOOVERSION }}
           build-args: |
             PYTHONBIN=${{ matrix.PYTHONBIN }}
+            DISTRO=${{ matrix.DISTRO }}
           tags: |
-            ghcr.io/${{ github.repository }}:${{ matrix.ODOOVERSION }}-${{ matrix.PYTHONTAG }}-latest
+            ghcr.io/${{ github.repository }}:${{ matrix.ODOOVERSION }}-${{ matrix.PYTHONTAG }}-${{ matrix.DISTRO }}-latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=inline
           push: true

--- a/Dockerfile-10.0
+++ b/Dockerfile-10.0
@@ -1,4 +1,7 @@
-FROM ubuntu:18.04
+ARG DISTRO=bionic
+
+FROM docker.io/ubuntu:$DISTRO
+
 MAINTAINER ACSONE SA/NV
 
 ARG PYTHONBIN=python2.7

--- a/Dockerfile-11.0
+++ b/Dockerfile-11.0
@@ -1,4 +1,7 @@
-FROM docker.io/ubuntu:18.04
+ARG DISTRO=bionic
+
+FROM docker.io/ubuntu:$DISTRO
+
 MAINTAINER ACSONE SA/NV
 
 ARG PYTHONBIN=python3.6

--- a/Dockerfile-12.0
+++ b/Dockerfile-12.0
@@ -1,4 +1,7 @@
-FROM docker.io/ubuntu:18.04
+ARG DISTRO=bionic
+
+FROM docker.io/ubuntu:$DISTRO
+
 MAINTAINER ACSONE SA/NV
 
 ARG PYTHONBIN=python3.6

--- a/Dockerfile-13.0
+++ b/Dockerfile-13.0
@@ -1,4 +1,7 @@
-FROM docker.io/ubuntu:18.04
+ARG DISTRO=bionic
+
+FROM docker.io/ubuntu:$DISTRO
+
 MAINTAINER ACSONE SA/NV
 
 ARG PYTHONBIN=python3.6

--- a/Dockerfile-14.0
+++ b/Dockerfile-14.0
@@ -1,4 +1,7 @@
-FROM docker.io/ubuntu:20.04
+ARG DISTRO=focal
+
+FROM docker.io/ubuntu:$DISTRO
+
 MAINTAINER ACSONE SA/NV
 
 ARG PYTHONBIN=python3.6

--- a/Dockerfile-15.0
+++ b/Dockerfile-15.0
@@ -1,4 +1,7 @@
-FROM docker.io/ubuntu:20.04
+ARG DISTRO=focal
+
+FROM docker.io/ubuntu:$DISTRO
+
 MAINTAINER ACSONE SA/NV
 
 ARG PYTHONBIN=python3.8

--- a/Dockerfile-16.0
+++ b/Dockerfile-16.0
@@ -1,4 +1,7 @@
-FROM docker.io/ubuntu:22.04
+ARG DISTRO=jammy
+
+FROM docker.io/ubuntu:$DISTRO
+
 MAINTAINER ACSONE SA/NV
 
 ARG PYTHONBIN=python3.10

--- a/Dockerfile-17.0
+++ b/Dockerfile-17.0
@@ -1,4 +1,7 @@
-FROM docker.io/ubuntu:22.04
+ARG DISTRO=jammy
+
+FROM docker.io/ubuntu:$DISTRO
+
 MAINTAINER ACSONE SA/NV
 
 ARG PYTHONBIN=python3.11

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -1,4 +1,7 @@
-FROM docker.io/ubuntu:18.04
+ARG DISTRO=bionic
+
+FROM docker.io/ubuntu:$DISTRO
+
 MAINTAINER ACSONE SA/NV
 
 ARG PYTHONBIN=python2.7

--- a/Dockerfile-9.0
+++ b/Dockerfile-9.0
@@ -1,4 +1,7 @@
-FROM docker.io/ubuntu:18.04
+ARG DISTRO=bionic
+
+FROM docker.io/ubuntu:$DISTRO
+
 MAINTAINER ACSONE SA/NV
 
 ARG PYTHONBIN=python2.7

--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,14 @@ structure.
 
 .. contents::
 
+Available image tags
+====================
+
+The CI of this projects build regularly for some combination of Odoo version, python
+version and Ubuntu version.
+
+The supported combinations are visible in the [build matrix](.github/workflows/ci.yml).
+
 Features exposed by these images
 ================================
 
@@ -21,10 +29,6 @@ Features exposed by these images
 
 * Ubuntu minimal because it's small and has recent pythons
   
-  * 22.04 for Odoo 16 and 17 images
-  * 20.04 for Odoo 14 and 15 images
-  * 18.04 for Odoo <= 13 images
-
 * ``python``, obviously. 
 * An entrypoint that generates the Odoo config file (``$ODOO_RC``) from environment
   variables (see the list of supported variables below).

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -2,8 +2,9 @@
 ARG IMAGE=ghcr.io/acsone/odoo-bedrock
 ARG ODOOVERSION=16.0
 ARG PYTHONTAG=py310
+ARG DISTRO=jammy
 
-FROM $IMAGE:$ODOOVERSION-$PYTHONTAG-latest
+FROM $IMAGE:$ODOOVERSION-$PYTHONTAG-$DISTRO-latest
 
 RUN apt-get update && apt-get install -y postgresql-client --no-install-recommends
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,5 +7,5 @@ Prerequisites to run the test suite are `python3`, `docker-compose` and `pytest`
 installed in the python environment.
 
 Tests are launched with `pytest -v ./tests`. They start with a `docker-compose build`
-using the `PYTHONTAG` and `ODOOVERSION` environment variables to determine the base
-`odoo-bedrock` image.
+using the `PYTHONTAG`, `DISTRO` and `ODOOVERSION` environment variables to determine the
+base `odoo-bedrock` image.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ def compose_build():
         cmd.extend(["--build-arg", f"ODOOVERSION={os.environ['ODOOVERSION']}"])
     if "PYTHONTAG" in os.environ:
         cmd.extend(["--build-arg", f"PYTHONTAG={os.environ['PYTHONTAG']}"])
+    if "DISTRO" in os.environ:
+        cmd.extend(["--build-arg", f"DISTRO={os.environ['DISTRO']}"])
     subprocess.run(cmd, check=True, cwd=HERE)
 
 


### PR DESCRIPTION
In this PR

- we stop building for very old pythons (2.7, 3.5)
- we stop building `bionic` images
- we add the distro (focal, jammy) in the image tags