### PR TITLE
17.0: don't preinstall setuptools and wheel

### DIFF
--- a/Dockerfile-17.0
+++ b/Dockerfile-17.0
@@ -29,7 +29,8 @@ RUN set -x \
 # isolate from system python libraries
 RUN set -x \
   && $PYTHONBIN -m venv /odoo \
-  && /odoo/bin/pip install -U pip wheel setuptools
+  && /odoo/bin/pip install -U pip \
+  && /odoo/bin/pip uninstall -y setuptools wheel
 ENV PATH=/odoo/bin:$PATH
 
 # odoo config file


### PR DESCRIPTION
This forces pip to use build isolation by default for legacy setup.py projects. Since OCA addons use pyproject.toml there is no reason to have setuptools pre-installed.