### PR TITLE
Properly activate the python venv

### DIFF
--- a/Dockerfile-11.0
+++ b/Dockerfile-11.0
@@ -32,6 +32,7 @@ RUN set -x \
   && $PYTHONBIN -m venv /odoo \
   && /odoo/bin/pip install -U pip wheel setuptools
 ENV PATH=/odoo/bin:$PATH
+ENV VIRTUAL_ENV=/odoo
 
 # odoo config file
 COPY ./templates/${ODOO_VERSION} /odoo/templates

--- a/Dockerfile-12.0
+++ b/Dockerfile-12.0
@@ -31,6 +31,7 @@ RUN set -x \
   && $PYTHONBIN -m venv /odoo \
   && /odoo/bin/pip install -U pip wheel setuptools
 ENV PATH=/odoo/bin:$PATH
+ENV VIRTUAL_ENV=/odoo
 
 # odoo config file
 COPY ./templates/${ODOO_VERSION} /odoo/templates

--- a/Dockerfile-13.0
+++ b/Dockerfile-13.0
@@ -31,6 +31,7 @@ RUN set -x \
   && $PYTHONBIN -m venv /odoo \
   && /odoo/bin/pip install -U pip wheel setuptools
 ENV PATH=/odoo/bin:$PATH
+ENV VIRTUAL_ENV=/odoo
 
 # odoo config file
 COPY ./templates/${ODOO_VERSION} /odoo/templates

--- a/Dockerfile-14.0
+++ b/Dockerfile-14.0
@@ -31,6 +31,7 @@ RUN set -x \
   && $PYTHONBIN -m venv /odoo \
   && /odoo/bin/pip install -U pip wheel setuptools
 ENV PATH=/odoo/bin:$PATH
+ENV VIRTUAL_ENV=/odoo
 
 # odoo config file
 COPY ./templates/${ODOO_VERSION} /odoo/templates

--- a/Dockerfile-15.0
+++ b/Dockerfile-15.0
@@ -31,6 +31,7 @@ RUN set -x \
   && $PYTHONBIN -m venv /odoo \
   && /odoo/bin/pip install -U pip wheel setuptools
 ENV PATH=/odoo/bin:$PATH
+ENV VIRTUAL_ENV=/odoo
 
 # odoo config file
 COPY ./templates/${ODOO_VERSION} /odoo/templates

--- a/Dockerfile-16.0
+++ b/Dockerfile-16.0
@@ -31,6 +31,7 @@ RUN set -x \
   && $PYTHONBIN -m venv /odoo \
   && /odoo/bin/pip install -U pip wheel setuptools
 ENV PATH=/odoo/bin:$PATH
+ENV VIRTUAL_ENV=/odoo
 
 # odoo config file
 COPY ./templates/${ODOO_VERSION} /odoo/templates

--- a/Dockerfile-17.0
+++ b/Dockerfile-17.0
@@ -31,6 +31,7 @@ RUN set -x \
   && $PYTHONBIN -m venv /odoo \
   && /odoo/bin/pip install -U pip wheel setuptools
 ENV PATH=/odoo/bin:$PATH
+ENV VIRTUAL_ENV=/odoo
 
 # odoo config file
 COPY ./templates/${ODOO_VERSION} /odoo/templates

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Features exposed by these images
 
 * Ubuntu minimal because it's small and has recent pythons
   
-* ``python``, obviously. 
+* ``python``, obviously, in an activated virtual environment.
 * An entrypoint that generates the Odoo config file (``$ODOO_RC``) from environment
   variables (see the list of supported variables below).
 * ``/usr/local/bin/wkhtmltopdf`` is the `kwkhtmltopdf


### PR DESCRIPTION
Set the `VIRTUAL_ENV` environment variables so the venv is properly activated.

This is important for tools that rely on that, such as `uv`.