### PR TITLE
[UPD] dockerfile-*: Update maintainer with new syntax

### DIFF
--- a/Dockerfile-10.0
+++ b/Dockerfile-10.0
@@ -2,7 +2,7 @@ ARG DISTRO=jammy
 
 FROM docker.io/ubuntu:$DISTRO
 
-MAINTAINER ACSONE SA/NV
+LABEL org.opencontainers.image.authors="ACSONE SA/NV"
 
 ARG PYTHONBIN=python2.7
 

--- a/Dockerfile-11.0
+++ b/Dockerfile-11.0
@@ -2,7 +2,7 @@ ARG DISTRO=bionic
 
 FROM docker.io/ubuntu:$DISTRO
 
-MAINTAINER ACSONE SA/NV
+LABEL org.opencontainers.image.authors="ACSONE SA/NV"
 
 ARG PYTHONBIN=python3.6
 

--- a/Dockerfile-12.0
+++ b/Dockerfile-12.0
@@ -2,7 +2,7 @@ ARG DISTRO=bionic
 
 FROM docker.io/ubuntu:$DISTRO
 
-MAINTAINER ACSONE SA/NV
+LABEL org.opencontainers.image.authors="ACSONE SA/NV"
 
 ARG PYTHONBIN=python3.6
 

--- a/Dockerfile-13.0
+++ b/Dockerfile-13.0
@@ -2,7 +2,7 @@ ARG DISTRO=bionic
 
 FROM docker.io/ubuntu:$DISTRO
 
-MAINTAINER ACSONE SA/NV
+LABEL org.opencontainers.image.authors="ACSONE SA/NV"
 
 ARG PYTHONBIN=python3.6
 

--- a/Dockerfile-14.0
+++ b/Dockerfile-14.0
@@ -2,7 +2,7 @@ ARG DISTRO=focal
 
 FROM docker.io/ubuntu:$DISTRO
 
-MAINTAINER ACSONE SA/NV
+LABEL org.opencontainers.image.authors="ACSONE SA/NV"
 
 ARG PYTHONBIN=python3.6
 

--- a/Dockerfile-15.0
+++ b/Dockerfile-15.0
@@ -2,7 +2,7 @@ ARG DISTRO=focal
 
 FROM docker.io/ubuntu:$DISTRO
 
-MAINTAINER ACSONE SA/NV
+LABEL org.opencontainers.image.authors="ACSONE SA/NV"
 
 ARG PYTHONBIN=python3.8
 

--- a/Dockerfile-16.0
+++ b/Dockerfile-16.0
@@ -2,7 +2,7 @@ ARG DISTRO=jammy
 
 FROM docker.io/ubuntu:$DISTRO
 
-MAINTAINER ACSONE SA/NV
+LABEL org.opencontainers.image.authors="ACSONE SA/NV"
 
 ARG PYTHONBIN=python3.10
 

--- a/Dockerfile-17.0
+++ b/Dockerfile-17.0
@@ -2,7 +2,7 @@ ARG DISTRO=jammy
 
 FROM docker.io/ubuntu:$DISTRO
 
-MAINTAINER ACSONE SA/NV
+LABEL org.opencontainers.image.authors="ACSONE SA/NV"
 
 ARG PYTHONBIN=python3.11
 

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -2,7 +2,7 @@ ARG DISTRO=jammy
 
 FROM docker.io/ubuntu:$DISTRO
 
-MAINTAINER ACSONE SA/NV
+LABEL org.opencontainers.image.authors="ACSONE SA/NV"
 
 ARG PYTHONBIN=python2.7
 

--- a/Dockerfile-9.0
+++ b/Dockerfile-9.0
@@ -2,7 +2,7 @@ ARG DISTRO=jammy
 
 FROM docker.io/ubuntu:$DISTRO
 
-MAINTAINER ACSONE SA/NV
+LABEL org.opencontainers.image.authors="ACSONE SA/NV"
 
 ARG PYTHONBIN=python2.7
 


### PR DESCRIPTION
`MAINTAINER` is deprecated and should be replaced with new syntax( `org.opencontainers.image.authors` ): https://docs.docker.com/reference/build-checks/maintainer-deprecated

https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

![image](https://github.com/user-attachments/assets/a02fbb99-41fc-417c-9dc4-a8a5cec8e586)
