### PR TITLE
Make db_filter regex optional if db_name is not set

### DIFF
--- a/templates/18.0/answers.sh
+++ b/templates/18.0/answers.sh
@@ -8,7 +8,10 @@ declare -x DB_NAME="${DB_NAME:-}"
 declare -x DB_USER="${DB_USER:-}"
 declare -x DB_PASSWORD="${DB_PASSWORD:-}"
 declare -x DB_SSLMODE="${DB_SSLMODE:-prefer}"
-declare -x DB_FILTER="${DB_FILTER:-^(${DB_NAME//,/|})$}"
+declare -x DB_FILTER="${DB_FILTER:-}"
+if [ -z "${DB_FILTER}" ] && [ -n "${DB_NAME}" ]; then
+    declare -x DB_FILTER="^(${DB_NAME//,/|})$"
+fi
 declare -x LIST_DB="${LIST_DB:-False}"
 declare -x ADMIN_PASSWD="${ADMIN_PASSWD:-}"
 declare -x DB_MAXCONN="${DB_MAXCONN:-64}"


### PR DESCRIPTION
Currently the Odoo 18.0 template sets a regex pattern on the DB_FILTER value if a DB_FILTER is not specified. However the regex pattern relies on having a DB_NAME set, which may not be set. If no DB_NAME is set, Odoo opens the database selector to create a database, but is not able to load the database because it is blocked by the non-applicable DB_FILTER value. So you're stuck in a loop :)

This might be helpful for others using your project, but I appreciate if setting a DB_NAME might be a good practice you follow or something you do on all your projects. If that's the case, please disregard the request. Thank you!