### PR TITLE
Build docker image before test

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,6 @@
 # Dockerfile to run tests
+
+# /!\ These defaults must match those in conftest.py
 ARG IMAGE=ghcr.io/acsone/odoo-bedrock
 ARG ODOOVERSION=16.0
 ARG PYTHONTAG=py310


### PR DESCRIPTION
Before we were not building so the test docker-compose was using the remote image and not the source we were testing.