### PR TITLE
entrypoint: add exit-on-error

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -24,9 +24,9 @@ if [ "$BASE_CMD" = "odoo" ] || [ "$BASE_CMD" = "odoo.py" ] || [ "$BASE_CMD" = "o
   START_ENTRYPOINT_DIR=/odoo/start-entrypoint.d
   if [ -d "$START_ENTRYPOINT_DIR" ]; then
     if [ -z "${NOGOSU:-}" ] ; then
-      gosu odoo run-parts --verbose "$START_ENTRYPOINT_DIR"
+      gosu odoo run-parts --exit-on-error --verbose "$START_ENTRYPOINT_DIR"
     else
-      run-parts --verbose "$START_ENTRYPOINT_DIR"
+      run-parts --exit-on-error --verbose "$START_ENTRYPOINT_DIR"
     fi
   fi
 fi


### PR DESCRIPTION
because you may add other scripts in start-entrypoint.d and you want to stop as soon as possible