### PR TITLE
v19: Use with_demo instead of without_demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Odoo options:
 - `SERVER_WIDE_MODULES` (\>=10)
 - `SYSLOG`
 - `UNACCENT`
+- `WITH_DEMO` (\>=19)
 - `WITHOUT_DEMO`
 - `WORKERS`
 

--- a/templates/19.0/answers.sh
+++ b/templates/19.0/answers.sh
@@ -29,7 +29,20 @@ declare -x LOGFILE="${LOGFILE:-None}"
 declare -x LOG_DB="${LOG_DB:-False}"
 declare -x SYSLOG="${SYSLOG:-False}"
 declare -x RUNNING_ENV="${RUNNING_ENV:-dev}"
-declare -x WITHOUT_DEMO="${WITHOUT_DEMO:-True}"
+if [ ! -z "${WITH_DEMO:-}" ]; then
+  declare -x WITH_DEMO="${WITH_DEMO}"
+elif [ ! -z "${WITHOUT_DEMO:-}" ]; then
+  # Fallback to WITHOUT_DEMO
+  # But inversing the logic
+  if [ "${WITHOUT_DEMO}" == "False" ]; then
+    declare -x WITH_DEMO="True"
+  else
+    declare -x WITH_DEMO="False"
+  fi
+else
+  # nothing is set -> Default value
+  declare -x WITH_DEMO="False"
+fi
 declare -x SERVER_WIDE_MODULES="${SERVER_WIDE_MODULES:-}"
 declare -x UNACCENT="${UNACCENT:-False}"
 declare -x ADDITIONAL_ODOO_RC="${ADDITIONAL_ODOO_RC:-}"

--- a/templates/19.0/odoo.cfg.tmpl
+++ b/templates/19.0/odoo.cfg.tmpl
@@ -33,7 +33,7 @@ log_db = ${LOG_DB}
 logrotate = True
 syslog = ${SYSLOG}
 running_env = ${RUNNING_ENV}
-without_demo = ${WITHOUT_DEMO}
+with_demo = ${WITH_DEMO}
 server_wide_modules = ${SERVER_WIDE_MODULES}
 ; We can activate proxy_mode even if we are not behind a proxy, because
 ; it is used only if HTTP_X_FORWARDED_HOST is set in environ

--- a/tests/data/expected-default-odoo-cfg-19.0.cfg
+++ b/tests/data/expected-default-odoo-cfg-19.0.cfg
@@ -33,7 +33,7 @@ log_db = False
 logrotate = True
 syslog = False
 running_env = dev
-without_demo = True
+with_demo = False
 server_wide_modules = 
 ; We can activate proxy_mode even if we are not behind a proxy, because
 ; it is used only if HTTP_X_FORWARDED_HOST is set in environ

--- a/tests/data/expected-odoo-cfg-19.0.cfg
+++ b/tests/data/expected-odoo-cfg-19.0.cfg
@@ -33,7 +33,7 @@ log_db = *LOG_DB*
 logrotate = True
 syslog = *SYSLOG*
 running_env = *RUNNING_ENV*
-without_demo = *WITHOUT_DEMO*
+with_demo = *WITH_DEMO*
 server_wide_modules = *SERVER_WIDE_MODULES*
 ; We can activate proxy_mode even if we are not behind a proxy, because
 ; it is used only if HTTP_X_FORWARDED_HOST is set in environ


### PR DESCRIPTION
Keeps backward compatibility with without_demo
If env var `WITH_DEMO` is not set, use `WITHOUT_DEMO` instead.

By default with_demo is set to False which is the previous behaviour of this project, with without_demo=True, but also the new behaviour of Odoo.