### PR TITLE
In 19.0, remove the running env entry in odoo.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,18 @@ Other variables that populate `$ODOO_RC`:
 
 - `RUNNING_ENV`: sets `options.running_env` for use by the [OCA
   server_environment](https://github.com/OCA/server-env) module.
+
+> [!WARNING]
+> Starting with 19, the `running_env` option is not set in `$ODOO_RC` anymore
+> because it causes an Odoo warning, and is redundant with the environment
+> variable that is supported natively by the `server_environment` module`.
+
 - `ADDITIONAL_ODOO_RC`: is appended verbatim a the end of `$ODOO_RC`.
+
+> [!TIP]
+> In recent versions of the `server_environment` modules, the `SERVER_ENV_CONFIG`
+> and `SERVER_ENV_CONFIG_SECRET` environment variables are supported, so they are
+> a better alternative to `ADDITIONAL_ODOO_RC`.
 
 The following environment variables are processed by the entrypoint, if
 the `psql` client is installed (which is not the case by default):

--- a/templates/19.0/odoo.cfg.tmpl
+++ b/templates/19.0/odoo.cfg.tmpl
@@ -32,7 +32,6 @@ logfile = ${LOGFILE}
 log_db = ${LOG_DB}
 logrotate = True
 syslog = ${SYSLOG}
-running_env = ${RUNNING_ENV}
 with_demo = ${WITH_DEMO}
 server_wide_modules = ${SERVER_WIDE_MODULES}
 ; We can activate proxy_mode even if we are not behind a proxy, because

--- a/tests/data/expected-default-odoo-cfg-19.0.cfg
+++ b/tests/data/expected-default-odoo-cfg-19.0.cfg
@@ -32,7 +32,6 @@ logfile = None
 log_db = False
 logrotate = True
 syslog = False
-running_env = dev
 with_demo = False
 server_wide_modules = 
 ; We can activate proxy_mode even if we are not behind a proxy, because

--- a/tests/data/expected-odoo-cfg-19.0.cfg
+++ b/tests/data/expected-odoo-cfg-19.0.cfg
@@ -32,7 +32,6 @@ logfile = *LOGFILE*
 log_db = *LOG_DB*
 logrotate = True
 syslog = *SYSLOG*
-running_env = *RUNNING_ENV*
 with_demo = *WITH_DEMO*
 server_wide_modules = *SERVER_WIDE_MODULES*
 ; We can activate proxy_mode even if we are not behind a proxy, because


### PR DESCRIPTION
The server_environment module supports the RUNNING_ENV variable, and Odoo 19 raises a warning about this unsupported option.

Since it is redundant we remove it to silence the warning.