### PR TITLE
[19.0] Remove auto_reload and logrotate options from 19.0 config

### DIFF
--- a/templates/19.0/odoo.cfg.tmpl
+++ b/templates/19.0/odoo.cfg.tmpl
@@ -1,7 +1,6 @@
 [options]
 addons_path = ${ADDONS_PATH}
 data_dir = /data/odoo
-auto_reload = False
 db_template = ${DB_TEMPLATE}
 db_host = ${DB_HOST}
 db_port = ${DB_PORT}
@@ -30,7 +29,6 @@ max_cron_threads = ${MAX_CRON_THREADS}
 workers = ${WORKERS}
 logfile = ${LOGFILE}
 log_db = ${LOG_DB}
-logrotate = True
 syslog = ${SYSLOG}
 with_demo = ${WITH_DEMO}
 server_wide_modules = ${SERVER_WIDE_MODULES}

--- a/tests/data/expected-default-odoo-cfg-19.0.cfg
+++ b/tests/data/expected-default-odoo-cfg-19.0.cfg
@@ -1,7 +1,6 @@
 [options]
 addons_path = 
 data_dir = /data/odoo
-auto_reload = False
 db_template = template1
 db_host = postgres
 db_port = 5432
@@ -30,7 +29,6 @@ max_cron_threads = 2
 workers = 4
 logfile = None
 log_db = False
-logrotate = True
 syslog = False
 with_demo = False
 server_wide_modules = 

--- a/tests/data/expected-odoo-cfg-19.0.cfg
+++ b/tests/data/expected-odoo-cfg-19.0.cfg
@@ -1,7 +1,6 @@
 [options]
 addons_path = *ADDONS_PATH*
 data_dir = /data/odoo
-auto_reload = False
 db_template = *DB_TEMPLATE*
 db_host = *DB_HOST*
 db_port = *DB_PORT*
@@ -30,7 +29,6 @@ max_cron_threads = *MAX_CRON_THREADS*
 workers = *WORKERS*
 logfile = *LOGFILE*
 log_db = *LOG_DB*
-logrotate = True
 syslog = *SYSLOG*
 with_demo = *WITH_DEMO*
 server_wide_modules = *SERVER_WIDE_MODULES*


### PR DESCRIPTION
They have been removed from upstream.

Towards #60 